### PR TITLE
Function call variant proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ Mirror the style of function declarations at call sites. Calls that fit on a sin
 let success = reticulateSplines(splines)
 ```
 
-If the call site must be wrapped, put each parameter on a new line, indented one additional level:
+If the call site must be wrapped, put each parameter on a new line, indented one additional level. The parenthesis may be placed either on the same line as the final argument or on its own line:
 
 ```swift
 let success = reticulateSplines(
@@ -534,6 +534,13 @@ let success = reticulateSplines(
   adjustmentFactor: 1.3,
   translateConstant: 2,
   comment: "normalize the display")
+
+let success = reticulateSplines(
+  spline: splines,
+  adjustmentFactor: 1.3,
+  translateConstant: 2,
+  comment: "normalize the display"
+)
 ```
 
 ## Closure Expressions

--- a/README.md
+++ b/README.md
@@ -526,15 +526,9 @@ Mirror the style of function declarations at call sites. Calls that fit on a sin
 let success = reticulateSplines(splines)
 ```
 
-If the call site must be wrapped, put each parameter on a new line, indented one additional level. The parenthesis may be placed either on the same line as the final argument or on its own line:
+If the call site must be wrapped, put each parameter on a new line, indented one additional level. The parenthesis must be placed on its own line:
 
 ```swift
-let success = reticulateSplines(
-  spline: splines,
-  adjustmentFactor: 1.3,
-  translateConstant: 2,
-  comment: "normalize the display")
-
 let success = reticulateSplines(
   spline: splines,
   adjustmentFactor: 1.3,


### PR DESCRIPTION
I suggest adding another variant of the calling function with multiple parameters. It looks more clear and easier to read for me as the closing parenthesis is placed on the same indent level as the start of construction.
BTW it's not my crazy idea 😁, google has the same [style](https://google.github.io/swift/#function-calls) 